### PR TITLE
corrupted documentation table with missing text

### DIFF
--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -143,7 +143,6 @@ By supplying the necessary attributes under a `vcs-repository` object, you can c
 | `data.attributes.setting-overwrites` | object  | none |   The keys in this object are attributes that have organization-level defaults. Each attribute key stores a boolean value which is `true` by default. To overwrite the default inherited value, set an attribute's value to `false`. For example, to set `execution-mode` as the organization default, set `setting-overwrites.execution-mode` to `false`. |
 | `data.relationships` | object | none | Specifies a group of workspace associations. |
 | `data.relationships.project.data.id` | string  | default project | The ID of the project to create the workspace in. If left blank, Terraform creates the workspace in the organization's default project. You must have permission to create workspaces in the project, either by organization-level permissions or team admin access to a specific project. |
-of tags to bind to this workspace. If left blank, Terraform creates the workspace without tag bindings. You must have permission to manage tags.|
 | `data.relationships.tag-bindings.data`          | list of objects | none | Specifies a list of tags to attach to the workspace. |
 | `data.relationships.tag-bindings.data.type`     | string | none | Must be `tag-bindings` for each object in the list. |
 | `data.relationships.tag-bindings.data.attributes.key`   | string | none | Specifies the tag key for each object in the list. |
@@ -158,7 +157,7 @@ _Without a VCS repository_
 {
   "data": {
     "attributes": {
-      "name": "workspace-1",
+      "name": "workspace-1"
     },
     "type": "workspaces",
     "relationships": {


### PR DESCRIPTION
### What

1. The documentation table is corrupted, with missing text (see the highlighted cell starting with “of tags to bind to this workspace”. I removed the entire row with that missing text.

<img width="1443" alt="Screenshot 2024-10-14 at 4 19 25 PM" src="https://github.com/user-attachments/assets/ef62add0-e785-4216-98c2-f2ecc79fc664">
2. There was an extra comma after the name attribute in the example payload for Without a VCS repository use-case. I just removed that.

### Why

1. The missing text in the table was creating confusion for the users while following the documentation.
2. Extra comma was giving an error while calling the API call 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
